### PR TITLE
Using role attached to instance rather than access key and access secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ module.exports = {
                     "workerInterval": "30",
                     "rotateInterval": "0 0 * * *",
                     "rotateModule": true,
+                    "roleAttached": false,
                     "aws": {
                       "credentials": {
                         "accessKeyId": "<AWS_ACCESS_KEY_ID>",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ module.exports = {
 ### Config Property Description
 #### S3 upload properties
 All of the following properties needs to defined for s3 upload to work.
+- `roleAttached` : If this is  true then your aws role will be used rather than aws credentials i.e. accessKeyId and secretAccessKey.
 - `aws.credentials.accessKeyId` (Defaults to `null`): This is access key id of your aws account.
 - `aws.credentials.secretAccessKey` (Defaults to `null`): This is secret key of your aws account.
 - `logBucketSetting.bucket` (Defaults to `null`): This is region of your s3 in aws.

--- a/app.js
+++ b/app.js
@@ -137,7 +137,7 @@ function delete_old(file) {
           ) {
               // var AWS      = require('aws-sdk');
               // var s3Stream = require('s3-upload-stream')(new AWS.S3(conf.aws.credentials));
-              if ( conf.aws.credentials.userole ){
+              if ( conf.userole ){
                 var awsS3 = require('aws-s3-promisified')()    
               } else {
                 var awsS3 = require('aws-s3-promisified')({

--- a/app.js
+++ b/app.js
@@ -138,8 +138,10 @@ function delete_old(file) {
               // var AWS      = require('aws-sdk');
               // var s3Stream = require('s3-upload-stream')(new AWS.S3(conf.aws.credentials));
               if ( conf.userole ){
+                console.log("in if")
                 var awsS3 = require('aws-s3-promisified')()    
               } else {
+                console.log("in else")
                 var awsS3 = require('aws-s3-promisified')({
                     accessKeyId: conf.aws.credentials.accessKeyId,
                     secretAccessKey: conf.aws.credentials.secretAccessKey,

--- a/app.js
+++ b/app.js
@@ -137,10 +137,14 @@ function delete_old(file) {
           ) {
               // var AWS      = require('aws-sdk');
               // var s3Stream = require('s3-upload-stream')(new AWS.S3(conf.aws.credentials));
-              var awsS3 = require('aws-s3-promisified')({
-                  accessKeyId: conf.aws.credentials.accessKeyId,
-                  secretAccessKey: conf.aws.credentials.secretAccessKey,
-              });
+              if ( conf.aws.credentials.userole ){
+                var awsS3 = require('aws-s3-promisified')()    
+              } else {
+                var awsS3 = require('aws-s3-promisified')({
+                    accessKeyId: conf.aws.credentials.accessKeyId,
+                    secretAccessKey: conf.aws.credentials.secretAccessKey,
+                });
+              }
               var currentTime = new Date();
               var key = `${conf.logBucketSetting.s3Path}/${(conf.logBucketSetting.s3FilePathFormat || '__filename__')
                   .replace(/__ip__/, SERVER_PUBLIC_IP || '')

--- a/app.js
+++ b/app.js
@@ -137,16 +137,15 @@ function delete_old(file) {
           ) {
               // var AWS      = require('aws-sdk');
               // var s3Stream = require('s3-upload-stream')(new AWS.S3(conf.aws.credentials));
-              if ( conf.userole ){
-                console.log("in if")
+              if ( conf.roleAttached ){
                 var awsS3 = require('aws-s3-promisified')()    
               } else {
-                console.log("in else")
-                var awsS3 = require('aws-s3-promisified')({
-                    accessKeyId: conf.aws.credentials.accessKeyId,
-                    secretAccessKey: conf.aws.credentials.secretAccessKey,
-                });
+                    var awsS3 = require('aws-s3-promisified')({
+                        accessKeyId: conf.aws.credentials.accessKeyId,
+                        secretAccessKey: conf.aws.credentials.secretAccessKey,
+                    });
               }
+              
               var currentTime = new Date();
               var key = `${conf.logBucketSetting.s3Path}/${(conf.logBucketSetting.s3FilePathFormat || '__filename__')
                   .replace(/__ip__/, SERVER_PUBLIC_IP || '')


### PR DESCRIPTION
We wanted to use role attached to ec2 instances rather than using credentials as it gets troublesome if you are doing auto-scaling. It will take a lot of time to go to each instance and change credentials if that's required plus it's not secure to do it this way.